### PR TITLE
added the ability to bootstrap from hmc

### DIFF
--- a/examples/nice_lord_of_rings.py
+++ b/examples/nice_lord_of_rings.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
 
     os.environ['CUDA_VISIBLE_DEVICES'] = ''
 
-    energy_fn = LordOfRings(display=False)
+    energy_fn = LordOfRings(display=True)
     discriminator = MLPDiscriminator([400, 400, 400])
     generator = create_nice_network(
         2, 2,

--- a/examples/nice_mog6.py
+++ b/examples/nice_mog6.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
 
     os.environ['CUDA_VISIBLE_DEVICES'] = ''
 
-    energy_fn = MixtureOfGaussians(display=False)
+    energy_fn = MixtureOfGaussians(display=True)
     discriminator = MLPDiscriminator([400, 400, 400])
     generator = create_nice_network(
         2, 2,


### PR DESCRIPTION
Hi,

I've added the ability to first use HMC as the sampler you bootstrap from. The way I've set it up, you can bootstrap from HMC for some number of training epochs and then it defaults to using the NICE proposal as the sampler. This way you don't have HMC as a ceiling.

Hopefully now you can train more successfully on higher-dimensional distributions where initialising randomly isnt good enough.

I've tested this out on the examples in the repo and it seems to work fine. I'm going to try to get it to work for posterior sampling for a neural net and an example.

Thanks,

Raza